### PR TITLE
WIP - success with reading repo topics in an action via GH cli

### DIFF
--- a/.github/workflows/exp_github_cli_action.yml
+++ b/.github/workflows/exp_github_cli_action.yml
@@ -6,8 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  display-context:
+  list-repo-topics:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          gh api repos/{owner}/{repo}/topics
+      - run: gh api repos/{owner}/{repo}/topics
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/exp_github_cli_action.yml
+++ b/.github/workflows/exp_github_cli_action.yml
@@ -9,6 +9,7 @@ jobs:
   list-repo-topics:
     runs-on: ubuntu-latest
     steps:
-      - run: gh api repos/{owner}/{repo}/topics
+      - run: |
+          gh api repos/{owner}/{repo}/topics
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/exp_github_cli_action.yml
+++ b/.github/workflows/exp_github_cli_action.yml
@@ -9,7 +9,8 @@ jobs:
   list-repo-topics:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          gh api repos/{owner}/{repo}/topics
-        env:
+      - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh api repos/$GH_REPO/topics

--- a/.github/workflows/exp_github_cli_action.yml
+++ b/.github/workflows/exp_github_cli_action.yml
@@ -12,4 +12,4 @@ jobs:
       - run: |
           gh api repos/{owner}/{repo}/topics
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ORG_BEST_FAMILY_REPOS_READ }}

--- a/.github/workflows/exp_github_cli_action.yml
+++ b/.github/workflows/exp_github_cli_action.yml
@@ -12,4 +12,4 @@ jobs:
       - run: |
           gh api repos/{owner}/{repo}/topics
         env:
-          GH_TOKEN: ${{ secrets.GH_ORG_BEST_FAMILY_REPOS_READ }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ugh.

Ive managed to find a way to capture a repo's topics via the GH CLI in a GH Action.
This was harder than it should have been.

For the next trick, I will need to stick the JSON object into some sort of variable for use by a later step. There is an example of that [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/using-github-cli-in-workflows).